### PR TITLE
Upgrade to Ubuntu/trusty64 and emacs-24.5

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,4 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "precise64"
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box = "ubuntu/trusty64"
   config.vm.provision "shell", path: "setup.sh"
 end

--- a/jedi-starter.el
+++ b/jedi-starter.el
@@ -1,6 +1,5 @@
 ;; Package setup
 
-(add-to-list 'load-path "~/.emacs.d") ; to find Emacs 23 package.el
 (require 'package)
 (package-initialize)
 (add-to-list 'package-archives

--- a/setup.sh
+++ b/setup.sh
@@ -27,11 +27,7 @@ sudo -u vagrant ln -sf /vagrant/jedi-starter.el $VAGRANT_HOME/.emacs.d/init.el
 
 # build dependencies
 $INSTALL build-essential
-$INSTALL texinfo libtinfo-dev libncurses5-dev
-
-# download emacs
-TEMPDIR=install-temp
-mkdir $TEMPDIR
+$INSTALL texinfo libtinfo-dev
 
 # compile
 EMACSBASE=emacs-24.5
@@ -49,4 +45,4 @@ sudo make install
 
 # and cleanup
 cd $VAGRANT_HOME
-rm -rf $TEMPDIR
+rm -rf $EMACSBASE

--- a/setup.sh
+++ b/setup.sh
@@ -20,28 +20,30 @@ VAGRANT_HOME=/home/vagrant
 cd $VAGRANT_HOME
 
 # link to our .emacs file
-sudo -u vagrant ln -s /vagrant/jedi-starter.el $VAGRANT_HOME/.emacs
+sudo -u vagrant mkdir -p $VAGRANT_HOME/.emacs.d
+sudo -u vagrant ln -sf /vagrant/jedi-starter.el $VAGRANT_HOME/.emacs.d/init.el
 
 # get emacs
 
 # build dependencies
 $INSTALL build-essential
-$INSTALL libgtk-3-dev
-$INSTALL libgif-dev libxpm-dev
-$INSTALL texinfo
-$INSTALL libtiff4-dev
+$INSTALL texinfo libtinfo-dev libncurses5-dev
 
 # download emacs
 TEMPDIR=install-temp
 mkdir $TEMPDIR
 
 # compile
-EMACSBASE=emacs-24.3
+EMACSBASE=emacs-24.5
 EMACSPKG="$EMACSBASE.tar.gz"
-curl -XGET -O "http://ftp.gnu.org/gnu/emacs/$EMACSPKG"
-tar xzvf $EMACSPKG
+if [ ! -f /vagrant/archive/$EMACSPKG ]; then
+    mkdir -p /vagrant/archive
+    curl -XGET -O "http://ftp.gnu.org/gnu/emacs/$EMACSPKG"
+    mv -f $EMACSPKG /vagrant/archive/
+fi
+tar xzvf /vagrant/archive/$EMACSPKG
 cd $EMACSBASE
-./configure
+./configure --without-all --with-zlib
 make
 sudo make install
 


### PR DESCRIPTION
Keep a local copy of EMACSPKG so we do not download again on re-provision
Configure Emacs with: --without-all --with-zlib
    to build a minimal terminal version of Emacs
Get rid of a couple libraries we no longer need.
Add libtinfo-dev  which is required to build emacs-24
